### PR TITLE
Add a second bookmarklet method

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -39,7 +39,7 @@
   <ol>
     <li>
       Select and copy all of the code in the textbox below (Tap it and choose "Select All", then "Copy")<br/>
-      <textarea id="bookmarklet">loading...</textarea>
+      <textarea id="bookmarklet-text">loading...</textarea>
     </li>
     <li>Bookmark this page (Using the "Share" button on the bottom bar)</li>
     <li>Open the bookmark manager (Using the book icon on the bottom bar)</li>
@@ -55,7 +55,7 @@
     <li>Ensure the bookmark/favourites bar is showing (⇧⌘B / ⇧^B for Chrome and Safari)</li>
     <li>
       Drag the following link to the bookmarks bar:<br/>
-      <a href="#" id="bookmarklink">Technology Audit</a>
+      <a href="#" id="bookmarklet-link">Technology Audit</a>
     </li>
   </ol>
 
@@ -66,8 +66,8 @@
       xhr.open('GET', 'tech-audit.bookmarklet.js', true);
       xhr.onreadystatechange = function() {
         if (xhr.readyState === 4 && xhr.status === 200) {
-          document.getElementById('bookmarklet').value = 'javascript:' + xhr.response;
-          document.getElementById('bookmarklink').href = 'javascript:' + xhr.response;
+          document.getElementById('bookmarklet-text').value = 'javascript:' + xhr.response;
+          document.getElementById('bookmarklet-link').href = 'javascript:' + xhr.response;
         }
       };
       xhr.send(null);

--- a/docs/index.html
+++ b/docs/index.html
@@ -32,9 +32,10 @@
 </head>
 <body>
   <h1>The Technology Audit Bookmarklet</h1>
-  <h2>Instructions</h2>
-  <p>Assumes you're using iOS and Safari. Steps might differ for other platforms.</p>
   <p><a href="https://github.com/ticky/tech-audit-bookmarklet">Fork this on Github</a></p>
+  <h2>Instructions</h2>
+  <h3>Method one</h3>
+  <p>Assumes you're using iOS and Safari. Steps might differ for other platforms.</p>
   <ol>
     <li>
       Select and copy all of the code in the textbox below (Tap it and choose "Select All", then "Copy")<br/>
@@ -48,6 +49,15 @@
     <li>Paste the contents of your clipboard</li>
     <li>Tap "Done"</li>
   </ol>
+  <h3>Method two</h3>
+  <p>Works well on Google Chrome and Safari for desktop, may work in other browsers.</p>
+  <ol>
+    <li>Ensure the bookmark/favourites bar is showing (⇧⌘B / ⇧^B for Chrome and Safari)</li>
+    <li>
+      Drag the following link to the bookmarks bar:<br/>
+      <a href="#" id="bookmarklink">Technology Audit</a>
+    </li>
+  </ol>
 
   <p>To use it on a page, simply open your bookmarks and tap "Technology Audit".</p>
 
@@ -57,6 +67,7 @@
       xhr.onreadystatechange = function() {
         if (xhr.readyState === 4 && xhr.status === 200) {
           document.getElementById('bookmarklet').value = 'javascript:' + xhr.response;
+          document.getElementById('bookmarklink').href = 'javascript:' + xhr.response;
         }
       };
       xhr.send(null);

--- a/docs/index.html
+++ b/docs/index.html
@@ -34,7 +34,16 @@
   <h1>The Technology Audit Bookmarklet</h1>
   <p><a href="https://github.com/ticky/tech-audit-bookmarklet">Fork this on Github</a></p>
   <h2>Instructions</h2>
-  <h3>Method one</h3>
+  <h3>Desktop</h3>
+  <p>Works well on Google Chrome and Safari for desktop, may work in other browsers.</p>
+  <ol>
+    <li>Ensure the bookmark/favourites bar is showing (⇧⌘B / ⇧^B for Chrome and Safari)</li>
+    <li>
+      Drag the following link to the bookmarks bar:<br/>
+      <a href="#" id="bookmarklet-link" onclick="event.preventDefault();alert('You gotta drag, not click!')">Technology Audit</a>
+    </li>
+  </ol>
+  <h3>Mobile</h3>
   <p>Assumes you're using iOS and Safari. Steps might differ for other platforms.</p>
   <ol>
     <li>
@@ -48,15 +57,6 @@
     <li>Tap the second text area, then tap the "x" button which appears</li>
     <li>Paste the contents of your clipboard</li>
     <li>Tap "Done"</li>
-  </ol>
-  <h3>Method two</h3>
-  <p>Works well on Google Chrome and Safari for desktop, may work in other browsers.</p>
-  <ol>
-    <li>Ensure the bookmark/favourites bar is showing (⇧⌘B / ⇧^B for Chrome and Safari)</li>
-    <li>
-      Drag the following link to the bookmarks bar:<br/>
-      <a href="#" id="bookmarklet-link">Technology Audit</a>
-    </li>
   </ol>
 
   <p>To use it on a page, simply open your bookmarks and tap "Technology Audit".</p>


### PR DESCRIPTION
Add a second method for adding the bookmarklet, using the bookmarks bar/favourites bar available on desktop browsers.

This can be a simple way for users to add a JS bookmarklet - I've seen it used in a bunch of places.